### PR TITLE
Add log driver definition

### DIFF
--- a/nas-docker/adguard_home_sync/adguard_home_sync.yaml
+++ b/nas-docker/adguard_home_sync/adguard_home_sync.yaml
@@ -7,6 +7,11 @@ services:
     container_name: "adguard_home_sync"
     restart: unless-stopped
     command: "run --config /config/config.yaml"
+    logging:
+      driver: "local"
+      options:
+        max-file: "5"
+        max-size: "5m"
     volumes:
       - "/etc/localtime:/etc/localtime:ro"
       - "/home/${USERNAME}/homelab-remote/nas-docker/adguard_home_sync/config.yaml:/config/config.yaml"

--- a/nas-docker/adguard_home_sync/adguard_home_sync.yaml
+++ b/nas-docker/adguard_home_sync/adguard_home_sync.yaml
@@ -10,7 +10,7 @@ services:
     logging:
       driver: "local"
       options:
-        max-file: "5"
+        max-file: "3"
         max-size: "5m"
     volumes:
       - "/etc/localtime:/etc/localtime:ro"

--- a/nas-docker/docker_proxy.yaml
+++ b/nas-docker/docker_proxy.yaml
@@ -6,6 +6,11 @@ services:
     image: "tecnativa/docker-socket-proxy:0.1"
     container_name: "docker_proxy"
     restart: unless-stopped
+    logging:
+      driver: "local"
+      options:
+        max-file: "3"
+        max-size: "5m"
     ports:
       - "2375:2375"
     volumes:

--- a/nas-docker/portainer_agent.yaml
+++ b/nas-docker/portainer_agent.yaml
@@ -1,11 +1,16 @@
 # Compose file for the Portainer Agent
-  
+
 version: "3.9"
 services:
   portainer_agent:
     image: "portainer/agent:2.16.2"
     container_name: "portainer_agent"
     restart: unless-stopped
+    logging:
+      driver: "local"
+      options:
+        max-file: "3"
+        max-size: "5m"
     ports:
       - "9001:9001"
     volumes:

--- a/primary-docker/calibre_web.yaml
+++ b/primary-docker/calibre_web.yaml
@@ -6,6 +6,11 @@ services:
     image: "lscr.io/linuxserver/calibre-web:0.6.19"
     container_name: "calibre_web"
     restart: unless-stopped
+    logging:
+      driver: "local"
+      options:
+        max-file: "3"
+        max-size: "5m"
     networks:
       - traefik-external
     volumes:

--- a/primary-docker/homepage.yaml
+++ b/primary-docker/homepage.yaml
@@ -6,6 +6,11 @@ services:
     image: "ghcr.io/benphelps/homepage:v0.5.1"
     container_name: "homepage"
     restart: unless-stopped
+    logging:
+      driver: "local"
+      options:
+        max-file: "3"
+        max-size: "5m"
     networks:
       - traefik-external
     volumes:

--- a/primary-docker/homer.yaml
+++ b/primary-docker/homer.yaml
@@ -6,6 +6,11 @@ services:
     image: "b4bz/homer:v22.11.2"
     container_name: "homer"
     restart: unless-stopped
+    logging:
+      driver: "local"
+      options:
+        max-file: "3"
+        max-size: "5m"
     networks:
       - traefik-external
     volumes:

--- a/primary-docker/paperless_ngx.yaml
+++ b/primary-docker/paperless_ngx.yaml
@@ -6,6 +6,11 @@ services:
     image: "postgres:13"
     container_name: "paperless_postgres"
     restart: unless-stopped
+    logging:
+      driver: "local"
+      options:
+        max-file: "3"
+        max-size: "5m"
     volumes:
       - "/etc/localtime:/etc/localtime:ro"
       - "/home/${USERNAME}/datastore/homelab/paperless_ngx/postgres:/var/lib/postgresql/data"
@@ -32,7 +37,8 @@ services:
       - "paperless_postgres"
       - "paperless_broker"
     healthcheck:
-      test: ["CMD", "curl", "-fs", "-S", "--max-time", "2", "http://localhost:8000"]
+      test:
+        ["CMD", "curl", "-fs", "-S", "--max-time", "2", "http://localhost:8000"]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/primary-docker/portainer_ee.yaml
+++ b/primary-docker/portainer_ee.yaml
@@ -6,6 +6,11 @@ services:
     image: "portainer/portainer-ee:2.17.0"
     container_name: "portainer"
     restart: unless-stopped
+    logging:
+      driver: "local"
+      options:
+        max-file: "3"
+        max-size: "5m"
     networks:
       - traefik-external
     volumes:

--- a/primary-docker/uptime_kuma.yaml
+++ b/primary-docker/uptime_kuma.yaml
@@ -6,6 +6,11 @@ services:
     image: "louislam/uptime-kuma:1.19.6"
     container_name: "uptime_kuma"
     restart: unless-stopped
+    logging:
+      driver: "local"
+      options:
+        max-file: "3"
+        max-size: "5m"
     networks:
       - traefik-external
     volumes:

--- a/primary-docker/wireguard_easy.yaml
+++ b/primary-docker/wireguard_easy.yaml
@@ -6,6 +6,11 @@ services:
     image: "weejewel/wg-easy:7"
     container_name: "wireguard_easy"
     restart: unless-stopped
+    logging:
+      driver: "local"
+      options:
+        max-file: "3"
+        max-size: "5m"
     networks:
       - traefik-external
     volumes:

--- a/shared-docker/adguard_home/adguard_home.yaml
+++ b/shared-docker/adguard_home/adguard_home.yaml
@@ -7,6 +7,11 @@ services:
     container_name: "adguard_home"
     hostname: "adguard_home-${DOCKER_HOSTNAME}"
     restart: unless-stopped
+    logging:
+      driver: "local"
+      options:
+        max-file: "3"
+        max-size: "5m"
     ports:
       - "53:53/tcp"
       - "53:53/udp"

--- a/shared-docker/autoheal.yaml
+++ b/shared-docker/autoheal.yaml
@@ -6,6 +6,11 @@ services:
     image: "willfarrell/autoheal:1.2.0"
     container_name: "autoheal"
     restart: unless-stopped
+    logging:
+      driver: "local"
+      options:
+        max-file: "3"
+        max-size: "5m"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
       - "/etc/localtime:/etc/localtime:ro"

--- a/shared-docker/diun.yaml
+++ b/shared-docker/diun.yaml
@@ -6,6 +6,11 @@ services:
     image: "ghcr.io/crazy-max/diun:4.23.1"
     container_name: "diun"
     restart: unless-stopped
+    logging:
+      driver: "local"
+      options:
+        max-file: "3"
+        max-size: "5m"
     volumes:
       - "/var/run/docker.sock:/var/run/docker.sock:ro"
       - "/home/${USERNAME}/homelab-sync/diun-${DOCKER_HOSTNAME}/:/data/"

--- a/shared-docker/dozzle.yaml
+++ b/shared-docker/dozzle.yaml
@@ -6,6 +6,11 @@ services:
     image: "amir20/dozzle:pr-2014"
     container_name: "dozzle"
     restart: unless-stopped
+    logging:
+      driver: "local"
+      options:
+        max-file: "3"
+        max-size: "5m"
     networks:
       - traefik-external
     volumes:

--- a/shared-docker/traefik.yaml
+++ b/shared-docker/traefik.yaml
@@ -6,12 +6,17 @@ services:
     image: "traefik:v2.9.4"
     container_name: "traefik"
     restart: unless-stopped
+    logging:
+      driver: "local"
+      options:
+        max-file: "3"
+        max-size: "5m"
     healthcheck:
-          test: ["CMD", "traefik", "healthcheck", "--ping"]
-          interval: 10s
-          timeout: 5s
-          retries: 3
-          start_period: 15s
+      test: ["CMD", "traefik", "healthcheck", "--ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
     networks:
       - traefik-external
     ports:


### PR DESCRIPTION
- Add `local` logging driver to all compose files.
    - This should resolve an issue where the disk eventually runs out of space.