### PR TITLE
ci(external-landing): add missing build step

### DIFF
--- a/.github/workflows/external-landing-cd.yaml
+++ b/.github/workflows/external-landing-cd.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches: [main]
     paths:
+      - ".github/workflows/external-landing**"
       - "external-landing/**"
 
 jobs:

--- a/.github/workflows/external-landing-cd.yaml
+++ b/.github/workflows/external-landing-cd.yaml
@@ -20,6 +20,7 @@ jobs:
         with:
           node-version: "latest"
       - run: "npm ci"
+      - run: "npm run build"
       - run: "npm run deploy"
         env:
           CLOUDFLARE_API_TOKEN: ${{secrets.CF_PAGES_KEY}}

--- a/.github/workflows/external-landing-ci.yaml
+++ b/.github/workflows/external-landing-ci.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches: [main]
     paths:
+      - ".github/workflows/external-landing**"
       - "external-landing/**"
 
 jobs:


### PR DESCRIPTION
Add missing build step to the `external-landing-cd` Action.

This should resolve the deployment error seen in [run 16](https://github.com/hugginsio/homelab/actions/runs/5696965020/job/15442946292).
